### PR TITLE
 Update latest-dependency action PR reviewers

### DIFF
--- a/.github/workflows/latest-dependencies.yml
+++ b/.github/workflows/latest-dependencies.yml
@@ -27,4 +27,4 @@ jobs:
         branch: latest-dep-update
         branch-suffix: short-commit-hash
         base: master
-        reviewers: sintel-dev/core
+        team-reviewers: core


### PR DESCRIPTION
Update the latest-dependency action to correctly request `team-review` on latest dependency update PRs
